### PR TITLE
feat:The options in the 'Category' field of the 'WhatsApp Message Template' doctype have been changed

### DIFF
--- a/frappe_meta_integration/fixtures/whatsapp_message_template.json
+++ b/frappe_meta_integration/fixtures/whatsapp_message_template.json
@@ -1,7 +1,7 @@
 [
  {
   "amended_from": null,
-  "category": "TRANSACTIONAL",
+  "category": "MARKETING",
   "docstatus": 0,
   "doctype": "WhatsApp Message Template",
   "footer": null,

--- a/frappe_meta_integration/whatsapp/doctype/whatsapp_message_template/whatsapp_message_template.json
+++ b/frappe_meta_integration/whatsapp/doctype/whatsapp_message_template/whatsapp_message_template.json
@@ -99,7 +99,7 @@
    "fieldname": "category",
    "fieldtype": "Select",
    "label": "Category",
-   "options": "\nTRANSACTIONAL\nMARKETING\nOTP",
+   "options": "\nUTILITY\nMARKETING\nAUTHENTICATION",
    "reqd": 1
   },
   {
@@ -143,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-01 21:37:18.914542",
+ "modified": "2024-01-16 12:09:14.455727",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Message Template",


### PR DESCRIPTION
## Feature description
The options in the 'Category' field of the 'WhatsApp Message Template' doctype have been changed.

## Output screenshots (optional)
![image](https://github.com/efeone/frappe_meta_integration/assets/84179426/dc802381-c4a7-4a13-8361-36081ee90ec4)
![image](https://github.com/efeone/frappe_meta_integration/assets/84179426/4a69c940-0e5f-47b7-98c1-864d1fb5f055)


## Was this feature tested on the browsers?
  - Chrome

